### PR TITLE
Add test coverage badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 ![GitHub Workflow Status (with event)](https://img.shields.io/github/actions/workflow/status/CSC207-2023Y-UofT/ai-playground/.github%2Fworkflows%2Fpublish-javadoc.yml?label=Deploy%20Documentation)
 ![GitHub Workflow Status (with event)](https://img.shields.io/github/actions/workflow/status/CSC207-2023Y-UofT/ai-playground/.github%2Fworkflows%2Flint.yml?label=Java%20Style%20Guide)
 
+![Test Coverage](badges/jacoco.svg)
+![Branch Coverage](badges/branches.svg)
+
 ## 📄 Project Documentation
 
 [_**Visit the documentation of this project**_](https://csc207-2023y-uoft.github.io/ai-playground/) to get more information in detail.


### PR DESCRIPTION
This pull request aims to enhance the visibility of our project's test coverage by adding a test coverage badge to the README file. By including this badge, we make it easier for contributors, users, and stakeholders to quickly assess the quality and comprehensiveness of our test suite.

## Changes Made
- Added a test coverage badge to the README file.
- Integrated a coverage reporting tool to track and calculate test coverage.
## Why is this important?
Maintaining a high level of test coverage is crucial for ensuring the reliability and stability of our software. The test coverage badge serves as a visual indicator of our commitment to producing robust code. This addition not only encourages transparency but also helps build trust among our community and potential users.